### PR TITLE
fix: frontend on k8s

### DIFF
--- a/udagram-frontend/Dockerfile
+++ b/udagram-frontend/Dockerfile
@@ -1,29 +1,16 @@
-# Use NodeJS base image
-FROM node:13
-
-# Create app directory
-WORKDIR /app
-
-# Install app dependencies by copying
-# package.json and package-lock.json
-COPY package*.json /app/
-
-# Install Ionic
-RUN npm install -g ionic
-# Install dependencies
-RUN npm install
-
-# Copy app source
-COPY . /app/
-
+## Build
+FROM beevelop/ionic AS ionic
+# Create the application directory
+WORKDIR /usr/src/app
+# Install the application dependencies
+# We can use wildcard to ensure both package.json AND package-lock.json are considered
+# where available (npm@5+)
+COPY package*.json ./
+RUN npm ci
+# Bundle app source
+COPY . .
 RUN ionic build
-
-#FROM nginx:alpine
-#RUN rm -rf /usr/share/nginx/html/*
-#COPY --from=build /app/www/ /usr/share/nginx/html/
-
-# Bind the port that the image will run on
-EXPOSE 8100
-
-# Define the Docker image's behavior at runtime
-CMD ["ionic", "serve", "--port=8100", "--address=0.0.0.0"]
+## Run 
+FROM nginx:alpine
+#COPY www /usr/share/nginx/html
+COPY --from=ionic /usr/src/app/www /usr/share/nginx/html


### PR DESCRIPTION
fix that frontend is giving 'invalid host header'. Change the docker to
use an ionic image instead of complete install